### PR TITLE
fix: validate signature for slack_source

### DIFF
--- a/apps/core/eave/core/public/requests/slack_sources.py
+++ b/apps/core/eave/core/public/requests/slack_sources.py
@@ -11,7 +11,7 @@ from . import util as eave_request_util
 async def query(
     input: eave_ops.GetSlackSource.RequestBody, request: fastapi.Request, response: fastapi.Response
 ) -> eave_ops.GetSlackSource.ResponseBody:
-    logger.debug("subscriptions.delete_subscription")
+    logger.debug("slack_source.query")
     await eave_request_util.validate_signature_or_fail(request=request)
 
     async with await eave_db.get_session() as session:


### PR DESCRIPTION
I looked into writing the middleware. The middleware implementation is trivial, but making it apply only to specific routes is less so. It looks like fastapi currently only supports dividing middleware based on the FastAPI app it was applied to, so you have to have a route prefix on any set of endpoints you want to apply the middleware to without affecting others.
e.g. https://github.com/tiangolo/fastapi/issues/1174#issuecomment-905851468

So if we divided our core api app from the oauth endpoints, we could add the middleware to the coreapi w/o adding it to oauth. But that's a lot more refactoring than I want to do rn 