### PR TITLE
fix: clean trailing whitespace from doc comment lines

### DIFF
--- a/libs/eave-stdlib-ts/src/function-documenting.ts
+++ b/libs/eave-stdlib-ts/src/function-documenting.ts
@@ -105,7 +105,6 @@ export async function updateDocumentation({
       });
 
       // if there were already existing docs, update them using newly written docs
-      // TODO: how to handle comment merging...
       let updatedDocs = newDocsResponse;
       if (funcData.comment) {
         updatedDocs = await openaiClient.createChatCompletion({
@@ -138,6 +137,12 @@ export async function updateDocumentation({
           ctx,
         });
       }
+
+      // clean updated docs; make sure we dont write white space that could be lint errors
+      updatedDocs = updatedDocs
+        .split("\n")
+        .map((line) => line.trimEnd())
+        .join("\n");
 
       funcData.updatedComment = updatedDocs;
     }),


### PR DESCRIPTION
Ticket link:
<!-- here -->

Quality of life improvement for inline-docs function. Will save customers (and us) lint failure headaches caused by possible trailing whitespace inside doc comments.

Did you run?:
- [x] unit tests
- [x] lint

