### PR TITLE
feat: remove gh repos from db on access loss

### DIFF
--- a/apps/github/src/events/event-registry.ts
+++ b/apps/github/src/events/event-registry.ts
@@ -6,6 +6,7 @@ import {
 import { GitHubOperationsContext } from "../types.js";
 import installationDeletedHandler from "./installation-deleted.js";
 import installationRepoAddedHandler from "./installation-repositories-added.js";
+import installationRepoRemovedHandler from "./installation-repositories-removed.js";
 import pullRequestClosedHandler from "./pull-request-closed.js";
 import pushHandler from "./push.js";
 
@@ -30,6 +31,8 @@ export function getEventHandler({
       return pullRequestClosedHandler;
     case "installation_repositories.added":
       return installationRepoAddedHandler;
+    case "installation_repositories.removed":
+      return installationRepoRemovedHandler;
     case "installation.deleted":
       return installationDeletedHandler;
     default:

--- a/apps/github/src/events/installation-repositories-removed.ts
+++ b/apps/github/src/events/installation-repositories-removed.ts
@@ -1,0 +1,52 @@
+import {
+  DeleteGithubRepoOperation,
+  GetGithubReposOperation,
+} from "@eave-fyi/eave-stdlib-ts/src/core-api/operations/github-repos.js";
+import { InstallationRepositoriesRemovedEvent } from "@octokit/webhooks-types";
+import { appConfig } from "../config.js";
+import { EventHandlerArgs } from "../types.js";
+
+/**
+ * Receives github webhook installation_repositories.removed events.
+ * https://docs.github.com/en/webhooks/webhook-events-and-payloads#installation_repositories
+ *
+ * Features:
+ * Removes entries from github_repos DB table that we no longer have permission to access
+ * through the GitHub API.
+ */
+export default async function handler({
+  event,
+  ctx,
+  eaveTeam,
+}: EventHandlerArgs & {
+  event: InstallationRepositoriesRemovedEvent;
+}) {
+  if (event.action !== "removed") {
+    return;
+  }
+
+  const sharedReqInput = {
+    teamId: eaveTeam.id,
+    origin: appConfig.eaveOrigin,
+    ctx,
+  };
+
+  // fetch the repos to delete
+  const res = await GetGithubReposOperation.perform({
+    ...sharedReqInput,
+    input: {
+      repos: event.repositories_removed.map((repo) => {
+        return { external_repo_id: repo.id.toString() };
+      }),
+    },
+  });
+
+  await DeleteGithubRepoOperation.perform({
+    ...sharedReqInput,
+    input: {
+      repos: res.repos.map((repo) => {
+        return { id: repo.id };
+      }),
+    },
+  });
+}


### PR DESCRIPTION
Ticket link:
https://eave-fyi.atlassian.net/browse/EAVE-323

Prevent Eave from showing in the dash (and running API docs on) github repos the app no longer has permission to access.

Did you run?:
- [ ] unit tests
- [x] lint

