### PR TITLE
fix: make dotenv build during setup work

### DIFF
--- a/develop/shared/bin/_build-dotenv
+++ b/develop/shared/bin/_build-dotenv
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+import re
+import sys
+import os
+import dotenv
+
+def parse_config(filepath: str) -> None:
+    _, extension = os.path.splitext(filepath)
+
+    match extension:
+        case ".py":
+            varnames = parse_python_config(filepath=filepath)
+        case ".ts":
+            varnames = parse_typescript_config(filepath=filepath)
+        case _:
+            print(f"Unsupported file type: {extension}")
+            return
+
+    dotenv_path = os.path.join(os.getenv("EAVE_HOME", ""), ".env")
+
+    existing_values = dotenv.dotenv_values(dotenv_path)
+
+    with open(dotenv_path, "a+") as f:
+        for varname in varnames:
+            if varname not in existing_values.keys():
+                # if env var is available, auto set it in .env, otherwise set placeholder
+                f.write(f"\n{varname}{'=' + envval if (envval := os.getenv(varname)) else ''}")
+                print(f"Added {varname} to .env")
+
+def parse_python_config(filepath: str) -> list[str]:
+    with open(filepath, "r") as f:
+        lines = f.readlines()
+
+    varnames = []
+
+    for line in lines:
+        if (m := re.search("getenv\\([\"']([^\"']+)[\"']", line)) is not None:
+            varnames.append(m.group(1))
+        elif (m := re.search("environ\\[[\"']([^\"']+)[\"']", line)) is not None:
+            varnames.append(m.group(1))
+        elif (m := re.search("get_secret\\([\"']([^\"']+)[\"']", line)) is not None:
+            varnames.append(m.group(1))
+        else:
+            pass
+
+    return varnames
+
+def parse_typescript_config(filepath: str) -> list[str]:
+    with open(filepath, "r") as f:
+        lines = f.readlines()
+
+    varnames = []
+
+    for line in lines:
+        if (m := re.search("process\\.env\\[[\"']([^\"']+)[\"']", line)) is not None:
+            varnames.append(m.group(1))
+        if (m := re.search("this\\.getSecret\\([\"']([^\"']+)[\"']", line)) is not None:
+            varnames.append(m.group(1))
+        else:
+            pass
+
+    return varnames
+
+if __name__ == "__main__":
+    filepath = sys.argv[1]
+    configs = [filepath]
+
+    _, extension = os.path.splitext(filepath)
+
+    match extension:
+        case ".py":
+            stdlib_config = os.path.join(
+                os.environ["EAVE_HOME"], "libs/eave-stdlib-py/src/eave/stdlib/config.py"
+            )
+            configs.append(stdlib_config)
+        case ".ts":
+            stdlib_config = os.path.join(
+                os.environ["EAVE_HOME"], "libs/eave-stdlib-ts/src/config.ts"
+            )
+            configs.append(stdlib_config)
+        case _:
+            pass
+
+    for config in configs:
+        parse_config(filepath=config)

--- a/develop/shared/bin/build-dotenv
+++ b/develop/shared/bin/build-dotenv
@@ -1,86 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env bash
 
-import re
-import sys
-import os
-import dotenv
+set -eu
 
-def parse_config(filepath: str) -> None:
-    _, extension = os.path.splitext(filepath)
+source "${EAVE_HOME}/develop/functions.bash"
 
-    match extension:
-        case ".py":
-            varnames = parse_python_config(filepath=filepath)
-        case ".ts":
-            varnames = parse_typescript_config(filepath=filepath)
-        case _:
-            print(f"Unsupported file type: {extension}")
-            return
-
-    dotenv_path = os.path.join(os.getenv("EAVE_HOME", ""), ".env")
-
-    existing_values = dotenv.dotenv_values(dotenv_path)
-
-    with open(dotenv_path, "a+") as f:
-        for varname in varnames:
-            if varname not in existing_values.keys():
-                # if env var is available, auto set it in .env, otherwise set placeholder
-                f.write(f"\n{varname}{'=' + envval if (envval := os.getenv(varname)) else ''}")
-                print(f"Added {varname} to .env")
-
-def parse_python_config(filepath: str) -> list[str]:
-    with open(filepath, "r") as f:
-        lines = f.readlines()
-
-    varnames = []
-
-    for line in lines:
-        if (m := re.search("getenv\\([\"']([^\"']+)[\"']", line)) is not None:
-            varnames.append(m.group(1))
-        elif (m := re.search("environ\\[[\"']([^\"']+)[\"']", line)) is not None:
-            varnames.append(m.group(1))
-        elif (m := re.search("get_secret\\([\"']([^\"']+)[\"']", line)) is not None:
-            varnames.append(m.group(1))
-        else:
-            pass
-
-    return varnames
-
-def parse_typescript_config(filepath: str) -> list[str]:
-    with open(filepath, "r") as f:
-        lines = f.readlines()
-
-    varnames = []
-
-    for line in lines:
-        if (m := re.search("process\\.env\\[[\"']([^\"']+)[\"']", line)) is not None:
-            varnames.append(m.group(1))
-        if (m := re.search("this\\.getSecret\\([\"']([^\"']+)[\"']", line)) is not None:
-            varnames.append(m.group(1))
-        else:
-            pass
-
-    return varnames
-
-if __name__ == "__main__":
-    filepath = sys.argv[1]
-    configs = [filepath]
-
-    _, extension = os.path.splitext(filepath)
-
-    match extension:
-        case ".py":
-            stdlib_config = os.path.join(
-                os.environ["EAVE_HOME"], "libs/eave-stdlib-py/src/eave/stdlib/config.py"
-            )
-            configs.append(stdlib_config)
-        case ".ts":
-            stdlib_config = os.path.join(
-                os.environ["EAVE_HOME"], "libs/eave-stdlib-ts/src/config.ts"
-            )
-            configs.append(stdlib_config)
-        case _:
-            pass
-
-    for config in configs:
-        parse_config(filepath=config)
+(
+    python-validate-version
+    python-activate-venv
+    python ${EAVE_HOME}/develop/shared/bin/_build-dotenv "$@"
+)


### PR DESCRIPTION
Just moved build-dotenv to _build-dotenv so I could activate the python venv before running the script.

Did you run?:
- [ ] unit tests
- [ ] lint

