### PR TITLE
fix: always set EAVE_HOME

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -58,9 +58,9 @@ function setenvvars() (
 		fi
 	fi
 
-  # since EAVE_HOME is locally exported at the top of the file,
-  # it will never be empty even when not saved in env/login file.
-  # So we'll always set it here.
+	# since EAVE_HOME is locally exported at the top of the file,
+	# it will never be empty even when not saved in env/login file.
+	# So we'll always set it here.
 	local value
 	value=$(pwd)
 	statusmsg -pa "Adding EAVE_HOME=$value to your environment."


### PR DESCRIPTION
Ticket link:
<!-- here -->

The setup script wasn't setting EAVE_HOME persistently in the shell login file due to the export at the top of the file always setting EAVE_HOME for the setup process.

Did you run?:
- [ ] unit tests
- [ ] lint

