### PR TITLE
feat(EAVE-234): Auto-update BQ view schemas on atom insertion

### DIFF
--- a/apps/core/eave/core/internal/atoms/controllers/base_atom_controller.py
+++ b/apps/core/eave/core/internal/atoms/controllers/base_atom_controller.py
@@ -63,7 +63,6 @@ class BaseAtomController:
                     friendly_name=view_def.friendly_name,
                     description=view_def.description,
                     view_query=view_def.build_view_query(dataset_id=self._dataset_id),
-                    schema=view_def.schema_fields,
                     ctx=ctx,
                 )
 

--- a/apps/core/eave/core/internal/lib/bq_client.py
+++ b/apps/core/eave/core/internal/lib/bq_client.py
@@ -121,7 +121,6 @@ class BigQueryClient:
         friendly_name: str,
         description: str,
         view_query: str,
-        schema: tuple[bigquery.SchemaField, ...],
         ctx: LogContext,
     ) -> bigquery.Table:
         local_table = self.construct_table(dataset_id=dataset_id, table_id=view_id)
@@ -129,7 +128,6 @@ class BigQueryClient:
         local_table.friendly_name = friendly_name
         local_table.description = description
         local_table.view_query = view_query
-        local_table.schema = schema
 
         remote_table = self.get_or_create_table(
             table=local_table,
@@ -138,7 +136,7 @@ class BigQueryClient:
 
         if remote_table.to_api_repr() != local_table.to_api_repr():
             self.update_table(
-                table=remote_table,
+                table=local_table,
                 ctx=ctx,
             )
 


### PR DESCRIPTION
Ticket link:
https://eave-fyi.atlassian.net/browse/EAVE-234

- makes it so customer BQ views will get their schema (determined by query) updated to match current backend schema definition (for those views defined in code atm) whenever a new atom is inserted for the view.

Did you run?:
- [x] unit tests
- [x] lint

